### PR TITLE
[code for portland] add time & address

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,13 +96,16 @@
               <div class="event-detail event-col event-col-mini">
                 <p>
                   Tuesday, July 29
+                  <em>6:00pm &ndash; 9:00pm</em>
                 </p>
               </div>
 
               <div class="event-detail event-col event-col-mini event-col-pivot">
                 <p>
                   Esri Portland R&amp;D Center<br/>
-                  <a href="http://calagator.org/venues/202394387">(Map)</a>
+                  309 SW 6th Ave, Suite 600<br/>
+                  Portland, OR 97204<br/>
+                  (<a href="http://calagator.org/venues/202394387">map</a>)
                 </p>
               </div>
 


### PR DESCRIPTION
I noticed the time and address were missing for the Code for Portland event on pdx.devweek.org, so I took the liberty of forking and making a pull request!

**before:**
![screen shot 2014-07-27 at 2 31 13 pm](https://cloud.githubusercontent.com/assets/427322/3715206/68e979c2-15d5-11e4-98a5-01762097bb8f.png)

**after:**
![screen shot 2014-07-27 at 2 31 04 pm](https://cloud.githubusercontent.com/assets/427322/3715207/69d6f3fa-15d5-11e4-8c89-9599db83e431.png)
